### PR TITLE
chore: bump version

### DIFF
--- a/laserwave.novaextension/CHANGELOG.md
+++ b/laserwave.novaextension/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.5.0 - 2021-11-03
+
+### Chore & Maintenance
+
+- `[core]` Add niv to manage nix deps. ([#20](https://github.com/hansjhoffman/nova-laserwave/pull/20)) Update extension & dev dependencies
+- `[core]` Update extension & dev dependencies
+
+### Fixes
+
+- `[syntax]` Ensure CSS `style.selector.pseudoclass` styles match `style.selector.pseudoelement`. ([#30](https://github.com/hansjhoffman/nova-laserwave/pull/30))
+
 ## v0.4.0 - 2021-08-14
 
 ### Features

--- a/laserwave.novaextension/extension.json
+++ b/laserwave.novaextension/extension.json
@@ -3,7 +3,7 @@
   "name": "LaserWave",
   "organization": "@hansjhoffman",
   "description": "A clean 80's synthwave / outrun inspired theme for Nova.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "categories": ["themes"],
   "license": "MIT",
   "repository": "https://github.com/hansjhoffman/nova-laserwave",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nova-laserwave",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A clean 80's synthwave / outrun inspired theme for Nova.",
   "author": "Hans Hoffman",
   "license": "MIT",


### PR DESCRIPTION
## v0.5.0 - 2021-11-03

### Chore & Maintenance

- `[core]` Add niv to manage nix deps. ([#20](https://github.com/hansjhoffman/nova-laserwave/pull/20)) Update extension & dev dependencies
- `[core]` Update extension & dev dependencies

### Fixes

- `[syntax]` Ensure CSS `style.selector.pseudoclass` styles match `style.selector.pseudoelement`. ([#30](https://github.com/hansjhoffman/nova-laserwave/pull/30))